### PR TITLE
chore: add pre-push hook to block direct pushes to main

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,14 @@ repos:
         always_run: true
         stages: [pre-commit]
 
+      - id: no-push-to-main
+        name: no-push-to-main
+        entry: bash -c 'branch=$(git rev-parse --abbrev-ref HEAD); if [ "$branch" = "main" ] || [ "$branch" = "master" ]; then echo "Direct push to $branch is not allowed. Use a feature branch and open a PR." >&2; exit 1; fi'
+        language: system
+        pass_filenames: false
+        always_run: true
+        stages: [pre-push]
+
       - id: version-parity
         name: version-parity
         entry: python -m pytest tests/test_version_parity.py -q --no-header --tb=short


### PR DESCRIPTION
## Summary
- Add `no-push-to-main` pre-push hook in `.pre-commit-config.yaml`
- GitHub ruleset updated: removed admin bypass so branch protection applies to everyone

## What changed
- **GitHub ruleset**: `bypass_actors` set to `[]` (was admin with `always` bypass)
- **Local hook**: pre-push stage blocks `git push` when on `main` or `master`

Two layers of protection: server-side (GitHub ruleset) + client-side (pre-push hook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)