### PR TITLE
fix: use GitHub App token so release-please PRs trigger CI

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,10 +16,16 @@ jobs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
+      - name: Generate token from GitHub App
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
       - id: release
         uses: googleapis/release-please-action@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
   publish-pypi:
     needs: release-please


### PR DESCRIPTION
## Summary
- Created GitHub App `smellcheck-release-bot` with Contents and Pull requests read/write permissions
- Installed the app on the `smellcheck` repo only
- Added `APP_ID` and `APP_PRIVATE_KEY` as repo secrets
- Updated `release-please.yml` to use `actions/create-github-app-token@v1` instead of `secrets.GITHUB_TOKEN`

## Why
PRs created by `GITHUB_TOKEN` don't trigger downstream workflows — this is an intentional GitHub limitation to prevent recursive loops. This caused CI checks on release-please PR #15 to show "Waiting for status to be reported" indefinitely.

Using a GitHub App installation token instead allows release-please PRs to trigger CI normally.

## Test plan
- [ ] Merge this PR to main
- [ ] Verify next release-please PR has CI checks running
- [ ] Close stale PR #15 (release-please will recreate it with the new token)

🤖 Generated with [Claude Code](https://claude.com/claude-code)