### PR TITLE
fix: skip PR template check for release-please PRs

### DIFF
--- a/.github/workflows/pr-template.yml
+++ b/.github/workflows/pr-template.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   validate-template:
-    if: github.actor != 'smellcheck-release-bot[bot]'
+    if: "!startsWith(github.head_ref, 'release-please--')"
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write


### PR DESCRIPTION
<!-- template:bugfix -->

## What does this PR fix?

PR template validation CI was posting failure comments on release-please PRs (#26) because the actor-based skip condition didn't match the actual bot identity.

## Root cause

The workflow condition `github.actor != 'smellcheck-release-bot[bot]'` didn't work because the CI context sees `github-actions[bot]` as the actor, not the app's bot account.

## Checklist

- [x] `pytest tests/ -v` passes
- [ ] Added a regression test in `tests/test_regressions.py` — N/A (workflow change, not detector code)
- [x] `smellcheck src/smellcheck/` self-check runs clean
- [x] No dependencies added (stdlib only)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Test plan

- [ ] Verify release-please PR #26 no longer triggers the template check after this merges
- [ ] Verify normal PRs still get template validation (this PR itself validates it)

## Additional context

Changed the job-level `if` condition from actor matching to branch name prefix matching: `!startsWith(github.head_ref, 'release-please--')`. This is deterministic — release-please always creates branches with this prefix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)