### PR TITLE
fix: add vendored __init__.py to release-please extra-files

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -16,6 +16,10 @@
           "type": "json",
           "path": ".claude-plugin/marketplace.json",
           "jsonpath": "$.plugins[0].version"
+        },
+        {
+          "type": "generic",
+          "path": "plugins/python-refactoring/skills/python-refactoring/scripts/smellcheck/__init__.py"
         }
       ],
       "changelog-sections": [


### PR DESCRIPTION
<!-- template:bugfix -->

## What does this PR fix?

Release PR #30 fails `test_vendored_init_version_matches` because release-please bumps `pyproject.toml` to `0.3.1` but the vendored `__init__.py` still has `__version__ = "0.3.0"`.

## Root cause

The vendored `plugins/.../scripts/smellcheck/__init__.py` (added in #29) was not listed in release-please's `extra-files` config, so it doesn't get version-bumped alongside `pyproject.toml` and `marketplace.json`.

## Checklist

- [x] `pytest tests/ -v` passes
- [ ] Added a regression test in `tests/test_regressions.py`
- [x] `smellcheck src/smellcheck/` self-check runs clean
- [x] No dependencies added (stdlib only)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Test plan

After merging, release-please regenerates PR #30 with the vendored `__init__.py` updated to `0.3.1`, and `test_vendored_init_version_matches` passes in CI.

## Additional context

The fix adds the vendored `__init__.py` to `release-please-config.json` `extra-files` with `type: generic` so the `x.y.z` version string gets updated automatically on every release PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)