### PR TITLE
fix: add release-please version markers to vendored __init__.py

### DIFF
--- a/plugins/python-refactoring/skills/python-refactoring/scripts/smellcheck/__init__.py
+++ b/plugins/python-refactoring/skills/python-refactoring/scripts/smellcheck/__init__.py
@@ -1,2 +1,4 @@
 """smellcheck -- vendored for Agent Skills (do not edit, run scripts/vendor-smellcheck.sh)."""
+# x-release-please-start-version
 __version__ = "0.3.0"
+# x-release-please-end

--- a/scripts/vendor-smellcheck.sh
+++ b/scripts/vendor-smellcheck.sh
@@ -12,7 +12,9 @@ cp "$SRC/detector.py" "$DEST/detector.py"
 
 cat > "$DEST/__init__.py" << EOF
 """smellcheck -- vendored for Agent Skills (do not edit, run scripts/vendor-smellcheck.sh)."""
+# x-release-please-start-version
 __version__ = "$VERSION"
+# x-release-please-end
 EOF
 
 echo "Vendored smellcheck $VERSION into skill bundle."


### PR DESCRIPTION
<!-- template:bugfix -->

## What does this PR fix?

Release PR #30 fails `test_vendored_init_version_matches` because release-please's `generic` updater never updates the vendored `__init__.py` — it stays at `0.3.0` while `pyproject.toml` is bumped to `0.3.1`.

## Root cause

The `generic` type in release-please `extra-files` requires `x-release-please-start-version` / `x-release-please-end` marker comments to locate version strings. PR #31 added the file to `extra-files` but without markers in the file itself, the updater has nothing to match against.

## Checklist

- [x] `pytest tests/ -v` passes
- [ ] Added a regression test in `tests/test_regressions.py`
- [x] `smellcheck src/smellcheck/` self-check runs clean
- [x] No dependencies added (stdlib only)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Test plan

- Verified marker block is detectable with regex matching release-please's pattern
- `test_vendored_init_version_matches` passes locally at current version
- After merging, release-please should regenerate PR #30 with `__init__.py` updated to `0.3.1`

## Additional context

The vendor script (`scripts/vendor-smellcheck.sh`) now emits the markers in generated `__init__.py` files, so future regenerations will also include them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)