### PR TITLE
feat: add config extends for shared config inheritance

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ smellcheck reads `[tool.smellcheck]` from the nearest `pyproject.toml`:
 
 ```toml
 [tool.smellcheck]
+extends = "base.toml"               # inherit from a shared config file
 select = ["SC101", "SC201", "SC701"]  # only run these checks (default: all)
 ignore = ["SC601", "SC202"]          # skip these checks
 per-file-ignores = {"tests/*" = ["SC201", "SC206"]}  # per-path overrides
@@ -122,6 +123,32 @@ cache-dir = ".smellcheck-cache"        # cache directory (default: .smellcheck-c
 ```
 
 CLI flags override config values.
+
+### Config inheritance (`extends`)
+
+Use `extends` to inherit settings from a shared base config:
+
+```toml
+# base.toml — shared across repos
+[tool.smellcheck]
+ignore = ["SC601"]
+fail-on = "warning"
+```
+
+```toml
+# pyproject.toml — project overrides
+[tool.smellcheck]
+extends = "base.toml"
+ignore = ["SC202"]  # adds to base; final ignore = ["SC601", "SC202"]
+```
+
+Multiple bases are supported — later entries override earlier ones for scalar values, while `ignore` lists are unioned and `per-file-ignores` are deep-merged:
+
+```toml
+extends = ["base.toml", "strict.toml"]
+```
+
+Paths are relative to the file containing the `extends` key. Chains are resolved recursively (up to 5 levels deep).
 
 ## Suppression
 


### PR DESCRIPTION
<!-- template:feature -->

## What does this PR do?

Add `extends` key to `[tool.smellcheck]` config for inheriting settings from shared base TOML files. Organizations with multiple Python repos can now maintain a single shared config and have projects inherit from it via `extends = "base.toml"`.

## Type of change

- [ ] New smell check
- [x] CLI / output improvement
- [x] Other feature

## Checklist

- [x] `pytest tests/ -v` passes
- [x] New check has a test in `tests/test_detector.py`
- [x] `smellcheck src/smellcheck/` self-check runs clean (or new findings are intentional)
- [x] No dependencies added (stdlib only)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## For new smell checks

N/A — this is a config infrastructure feature, not a new smell check.

## Test plan

- 6 unit tests for `_merge_smellcheck_configs` (override select, union ignore, deep merge per-file-ignores, scalar override, extends stripped, scalar codes warning)
- 11 integration tests for `_resolve_extends` (single file, multiple files, recursive chain, relative paths, cycle detection, depth limit, missing file, no section, invalid type, non-string entries, absent)
- 6 additional tests (empty string warning, diamond dependency, symlink cycle, path traversal allowed, tomllib=None fallback, E2E scan)
- Full suite: 165/165 passing
- Self-check: `smellcheck src/smellcheck/ --min-severity warning` clean

## Additional context

- Closes #10
- Follows the pattern established by ruff (`extend = "base.toml"`) and eslint (`extends`)
- Strategy-aware merging: `select` overrides, `ignore` unions, `per-file-ignores` deep-merges, scalars override
- Safety guards: cycle detection (symlink-aware), chain depth limit (5), graceful warnings for missing/invalid files
- Diamond dependency support: sibling extends branches resolve shared bases independently
- Type validation: per-file-ignores values must be lists, extends entries must be non-empty strings
- Path traversal intentionally allowed (config author trust model, matches ruff/eslint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)