### PR TITLE
test: add extends absolute path test

### DIFF
--- a/tests/test_detector.py
+++ b/tests/test_detector.py
@@ -2223,6 +2223,22 @@ def test_extends_path_traversal_allowed(tmp_path):
     assert "SC601" in config["ignore"]
 
 
+def test_extends_absolute_path(tmp_path):
+    """Absolute paths in extends work correctly."""
+    base = tmp_path / "base.toml"
+    _write_toml(base, """\
+        [tool.smellcheck]
+        ignore = ["SC601"]
+    """)
+    _write_toml(tmp_path / "pyproject.toml", f"""\
+        [tool.smellcheck]
+        extends = "{base.resolve().as_posix()}"
+    """)
+    config = load_config(tmp_path)
+    assert "SC601" in config["ignore"]
+    assert "extends" not in config
+
+
 def test_extends_without_tomllib(tmp_path, monkeypatch):
     """When tomllib is unavailable, extends is silently skipped."""
     import smellcheck.detector as det


### PR DESCRIPTION
<!-- template:feature -->

## What does this PR do?

Add a test verifying that `extends` works with absolute file paths, not just relative paths.

## Type of change

- [ ] New smell check
- [ ] CLI / output improvement
- [x] Other feature

## Checklist

- [x] `pytest tests/ -v` passes
- [x] New check has a test in `tests/test_detector.py`
- [x] `smellcheck src/smellcheck/` self-check runs clean (or new findings are intentional)
- [x] No dependencies added (stdlib only)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## For new smell checks

N/A

## Test plan

- `test_extends_absolute_path` creates a base config, references it by absolute path in `extends`, and verifies the config is inherited correctly.

## Additional context

Complements the existing relative path (`test_extends_relative_path`) and parent traversal (`test_extends_path_traversal_allowed`) tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)