### PR TITLE
fix: sync plugin.json version with release-please

### DIFF
--- a/plugins/python-refactoring/.claude-plugin/plugin.json
+++ b/plugins/python-refactoring/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "python-refactoring",
   "description": "Python refactoring catalog with 83 patterns. AST-based code smell detection + actionable refactoring guidance with before/after examples.",
-  "version": "0.1.1"
+  "version": "0.3.4"
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -18,6 +18,11 @@
           "jsonpath": "$.plugins[0].version"
         },
         {
+          "type": "json",
+          "path": "plugins/python-refactoring/.claude-plugin/plugin.json",
+          "jsonpath": "$.version"
+        },
+        {
           "type": "generic",
           "path": "plugins/python-refactoring/skills/python-refactoring/scripts/smellcheck/__init__.py"
         }

--- a/tests/test_version_parity.py
+++ b/tests/test_version_parity.py
@@ -4,6 +4,7 @@ All of these must agree:
   - pyproject.toml          [project] version
   - .release-please-manifest.json  "."
   - .claude-plugin/marketplace.json  metadata.version + plugins[0].version
+  - plugins/python-refactoring/.claude-plugin/plugin.json  version
   - smellcheck.__version__  (importlib.metadata, derived from pyproject.toml)
 """
 
@@ -74,7 +75,11 @@ def _collect() -> list[tuple[str, str]]:
     # 4. marketplace.json — plugins[0].version
     sources.append(("marketplace.json plugins[0].version", mp["plugins"][0]["version"]))
 
-    # 5. Runtime __version__
+    # 5. plugin.json — version
+    pj = _read_json("plugins/python-refactoring/.claude-plugin/plugin.json")
+    sources.append(("plugin.json version", pj["version"]))
+
+    # 6. Runtime __version__
     from smellcheck import __version__
     sources.append(("smellcheck.__version__", __version__))
 


### PR DESCRIPTION
<!-- template:feature -->

## What does this PR do?

Fixes plugin version drift that caused `claude plugin update` to report "already at latest" when the plugin was actually outdated. The `plugin.json` file (which Claude Code reads for version comparison) was stuck at `0.1.1` while `marketplace.json` was at `0.3.4`.

## Type of change

- [ ] New smell check
- [x] CLI / output improvement
- [ ] Other feature

## Checklist

- [x] `pytest tests/ -v` passes
- [x] `smellcheck src/smellcheck/` self-check runs clean
- [x] No dependencies added (stdlib only)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## For new smell checks

N/A — this is a build/release fix, not a new smell check.

## Test plan

- [x] Version parity test includes `plugin.json` and passes
- [x] After merge + release, `claude plugin update python-refactoring@smellcheck` should detect new version

## Additional context

Changes:
1. **`plugins/python-refactoring/.claude-plugin/plugin.json`** — bumped version from `0.1.1` to `0.3.4`
2. **`release-please-config.json`** — added `plugin.json` to `extra-files` so future releases bump it automatically
3. **`tests/test_version_parity.py`** — added `plugin.json` to version parity checks so CI catches drift