### PR TITLE
feat: Cursor native plugin for python-refactoring

### DIFF
--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -1,0 +1,24 @@
+{
+  "name": "smellcheck",
+  "owner": {
+    "name": "Cheick Berthe",
+    "email": "cheick@example.com"
+  },
+  "metadata": {
+    "description": "Python code smell detector with 83 patterns mapped to a refactoring catalog. AST-based, zero dependencies, stdlib only.",
+    "version": "0.3.5"
+  },
+  "plugins": [
+    {
+      "name": "python-refactoring",
+      "source": "plugins/python-refactoring",
+      "description": "Python refactoring catalog with 83 patterns covering immutability, class design, control flow, architecture, OO metrics, and Python idioms. Analyze code for smells and apply numbered refactoring patterns.",
+      "version": "0.3.5",
+      "author": { "name": "Cheick Berthe" },
+      "license": "MIT",
+      "keywords": ["python", "refactoring", "code-smells", "ast", "static-analysis", "code-quality"],
+      "category": "developer-tools",
+      "logo": "https://raw.githubusercontent.com/cheickmec/smellcheck/main/assets/logo.png"
+    }
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ venv/
 .idea/
 .serena/
 .claude/
+.cursor/
 .omc/
 uv.lock
 logo-candidates/

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ smellcheck myfile.py --format json
 smellcheck src/ --min-severity warning --fail-on warning
 ```
 
-Also available as a **GitHub Action**, **pre-commit hook**, **SARIF/Code Scanning** integration, and **[Agent Skills](https://agentskills.io) plugin** for Claude Code, Cursor, Copilot, Gemini CLI, and more.
+Also available as a **GitHub Action**, **pre-commit hook**, **SARIF/Code Scanning** integration, **[Agent Skills](https://agentskills.io) plugin**, and **Cursor native plugin** for Claude Code, Cursor, Copilot, Gemini CLI, and more.
 
 **[Full installation guide →](https://github.com/cheickmec/smellcheck/blob/main/docs/installation.md)**
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -110,6 +110,15 @@ npx ai-agent-skills install cheickmec/smellcheck
 
 ### Cursor
 
+**Option A — Native plugin (recommended)**  
+Install the Cursor plugin so the skill and rules are discovered automatically:
+
+- In Cursor: **Settings → Plugins → Add plugin from folder** and choose the `plugins/python-refactoring` directory from a clone of this repo, or
+- If published to the Cursor plugin marketplace: **Settings → Plugins** and search for "Python Refactoring" / "python-refactoring".
+
+The plugin provides the `python-refactoring` skill and an optional rule that applies when editing Python files.
+
+**Option B — Skill only**  
 Copy the skill directory into your project's `.cursor/skills/` folder:
 
 ```bash
@@ -119,7 +128,7 @@ cp -r /tmp/smellcheck/plugins/python-refactoring/skills/python-refactoring .curs
 rm -rf /tmp/smellcheck
 ```
 
-Restart Cursor -- the agent auto-discovers skills in `.cursor/skills/`.
+Restart Cursor — the agent auto-discovers skills in `.cursor/skills/`.
 
 For global installation (all projects), copy to `~/.cursor/skills/` instead.
 

--- a/plugins/python-refactoring/.cursor-plugin/plugin.json
+++ b/plugins/python-refactoring/.cursor-plugin/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "python-refactoring",
+  "displayName": "Python Refactoring",
+  "version": "0.3.5",
+  "description": "Python refactoring catalog with 83 patterns. AST-based code smell detection + actionable refactoring guidance with before/after examples.",
+  "author": { "name": "Cheick Berthe" },
+  "license": "MIT",
+  "keywords": ["python", "refactoring", "code-smells", "ast", "static-analysis", "code-quality"],
+  "logo": "https://raw.githubusercontent.com/cheickmec/smellcheck/main/assets/logo.png",
+  "skills": "./skills/",
+  "rules": "./rules/"
+}

--- a/plugins/python-refactoring/rules/python-refactoring.mdc
+++ b/plugins/python-refactoring/rules/python-refactoring.mdc
@@ -1,0 +1,15 @@
+---
+description: When refactoring or improving Python code, use the python-refactoring skill to map smells to the 83-pattern catalog and apply before/after refactorings from the reference files.
+alwaysApply: false
+globs: ["**/*.py"]
+---
+
+# Python refactoring
+
+When the user asks to refactor, clean up, or improve Python code quality:
+
+1. Use the **python-refactoring** skill to identify smells and map them to pattern codes (SC1xx–SC8xx).
+2. Load the relevant reference file (state, functions, types, control, architecture, hygiene, idioms, metrics) for before/after guidance.
+3. Prefer the numbered refactoring patterns and note trade-offs.
+
+Run smellcheck (CLI or bundled script in the skill) when analyzing existing codebases.


### PR DESCRIPTION
<!-- template:feature -->

## What does this PR do?

Adds a Cursor-native plugin so the python-refactoring skill can be installed via Cursor’s plugin system (Settings → Plugins) and submitted to the Cursor marketplace. The same skill content is used by both Agent Skills (Claude, etc.) and Cursor; no duplication.

## Type of change

- [ ] New smell check
- [ ] CLI / output improvement
- [x] Other feature

## Checklist

- [x] `pytest tests/ -v` passes (existing suite; no detector changes)
- [ ] New check has a test in `tests/test_detector.py` — N/A (plugin metadata/docs only)
- [x] `smellcheck src/smellcheck/` self-check runs clean (or new findings are intentional)
- [x] No dependencies added (stdlib only)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## For new smell checks

N/A — this PR adds Cursor plugin manifest, rule, and docs only.

## Test plan

- Installed plugin locally: Cursor → Settings → Plugins → Add plugin from folder → selected `plugins/python-refactoring`. Skill and rule load correctly.
- Confirmed root `.cursor-plugin/marketplace.json` and `plugins/python-refactoring/.cursor-plugin/plugin.json` are valid JSON and paths are relative.

## Additional context

- Root `.cursor-plugin/marketplace.json` is for Cursor marketplace submission (plugin source: `plugins/python-refactoring`).
- Logo uses repo URL: `https://raw.githubusercontent.com/cheickmec/smellcheck/main/assets/logo.png`.
- `.cursor/` added to `.gitignore` so local Cursor config is not committed.
