### PR TITLE
fix: correct SC307 severity in README from warning to info

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ Every rule is identified by an **SC code** (e.g. `SC701`). Use SC codes in `--se
 | SC304 | Dataclass candidate | info |
 | SC305 | Sequential tuple indexing | info |
 | SC306 | Lazy class (<2 methods) | info |
-| SC307 | Temporary fields | warning |
+| SC307 | Temporary fields | info |
 | SC401 | Dead code after return | warning |
 | SC402 | Deep nesting (>4 levels) | warning |
 | SC403 | Loop + append pattern | info |


### PR DESCRIPTION
<!-- template:feature -->

## What does this PR do?

Fixes a documentation discrepancy where SC307 (Temporary fields) was listed as `warning` severity in the README, but the source of truth in `detector.py`'s `_RULE_REGISTRY` has it as `info`.

## Type of change

- [x] CLI / output improvement
- [ ] New smell check
- [ ] Other feature

## Checklist

- [x] `pytest tests/ -v` passes
- [x] `smellcheck src/smellcheck/` self-check runs clean
- [x] No dependencies added (stdlib only)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## For new smell checks

N/A — documentation fix only.

## Test plan

- [x] Verified `_RULE_REGISTRY["SC307"]` has severity `info` in `detector.py`
- [x] README now matches registry

## Additional context

Discovered during analysis of rule ordering for remediation. The registry in `detector.py` is the source of truth for severity levels.