### PR TITLE
fix: cross-file analysis bugs (#75, #76)

### DIFF
--- a/plugins/python-refactoring/skills/python-refactoring/scripts/smellcheck/detector.py
+++ b/plugins/python-refactoring/skills/python-refactoring/scripts/smellcheck/detector.py
@@ -3518,7 +3518,7 @@ def _detect_cyclic_imports(all_data: list[FileData]) -> list[Finding]:
         if key in reported:
             continue
         reported.add(key)
-        cycle_str = " -> ".join(normalized) + " -> " + normalized[0]
+        cycle_str = " -> ".join(f"`{m}`" for m in normalized) + " -> `" + normalized[0] + "`"
         findings.append(
             _make_finding(
                 file=reverse_map.get(normalized[0], normalized[0]),

--- a/src/smellcheck/detector.py
+++ b/src/smellcheck/detector.py
@@ -3518,7 +3518,7 @@ def _detect_cyclic_imports(all_data: list[FileData]) -> list[Finding]:
         if key in reported:
             continue
         reported.add(key)
-        cycle_str = " -> ".join(normalized) + " -> " + normalized[0]
+        cycle_str = " -> ".join(f"`{m}`" for m in normalized) + " -> `" + normalized[0] + "`"
         findings.append(
             _make_finding(
                 file=reverse_map.get(normalized[0], normalized[0]),

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -199,20 +199,20 @@ def test_cross_file_duplicate_stem_not_dropped(tmp_path):
     pkg2 = tmp_path / "pkg2"
     pkg1.mkdir()
     pkg2.mkdir()
-    # pkg1/utils.py imports pkg2's utils (via stem "utils")
+    # pkg1/utils.py imports pkg2's utils
     (pkg1 / "utils.py").write_text(
-        "import utils\ndef helper1(): pass\n", encoding="utf-8"
+        "import pkg2.utils\ndef helper1(): pass\n", encoding="utf-8"
     )
-    # pkg2/utils.py imports pkg1's utils (via stem "utils")
+    # pkg2/utils.py imports pkg1's utils
     (pkg2 / "utils.py").write_text(
-        "import utils\ndef helper2(): pass\n", encoding="utf-8"
+        "import pkg1.utils\ndef helper2(): pass\n", encoding="utf-8"
     )
     # Key invariant: scanning 2 files must not silently reduce to 1.
     # Verify both files are individually scannable.
     from smellcheck.detector import scan_file, _build_module_maps
     fd1 = scan_file(pkg1 / "utils.py")
     fd2 = scan_file(pkg2 / "utils.py")
-    assert fd1 is not None and fd2 is not None, "Both files must be scannable"
+    assert isinstance(fd1, tuple) and isinstance(fd2, tuple), "scan_file must return (findings, FileData)"
     # Verify the module map doesn't collapse duplicate stems.
     all_data = [fd1[1], fd2[1]]
     module_map, _ = _build_module_maps(all_data)


### PR DESCRIPTION
<!-- template:bugfix -->

## What does this PR fix?

Two cross-file analysis bugs:
- #75: N-node import cycles produce N findings instead of 1
- #76: Files with duplicate Path.stem silently dropped from analysis

Fixes #75, fixes #76

## Root cause

- **#75**: Cycle deduplication used `frozenset({src, dst})` on individual edges. All edges in the same cycle produce distinct frozensets.
- **#76**: `reverse_map = {v: k for k, v in module_map.items()}` where values are `Path.stem` — duplicate stems overwrite earlier entries.

## Checklist

- [x] `pytest tests/ -v` passes
- [x] Added a regression test in `tests/test_regressions.py`
- [x] `smellcheck src/smellcheck/` self-check runs clean
- [x] No dependencies added (stdlib only)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Test plan

- [x] test_cyclic_import_three_node_single_finding — 3-node cycle produces exactly 1 SC503 finding
- [x] test_cross_file_duplicate_stem_not_dropped — two files with same stem both analyzed

## Additional context

Closes #75, closes #76