### PR TITLE
fix: output and config bugs (#77, #80, #81, #82)

### DIFF
--- a/plugins/python-refactoring/skills/python-refactoring/scripts/smellcheck/detector.py
+++ b/plugins/python-refactoring/skills/python-refactoring/scripts/smellcheck/detector.py
@@ -1333,6 +1333,12 @@ def _load_baseline(path: Path) -> set[str]:
                 file=sys.stderr,
             )
             continue
+        if not isinstance(fp, str):
+            print(
+                f"Warning: skipping malformed baseline entry (non-string 'fingerprint'): {entry!r}",
+                file=sys.stderr,
+            )
+            continue
         fps.add(fp)
     return fps
 
@@ -4283,6 +4289,7 @@ def _escape_workflow_value(s: str) -> str:
         .replace("\r", "%0D")
         .replace("\n", "%0A")
         .replace(":", "%3A")
+        .replace(",", "%2C")
     )
 
 

--- a/src/smellcheck/detector.py
+++ b/src/smellcheck/detector.py
@@ -1333,6 +1333,12 @@ def _load_baseline(path: Path) -> set[str]:
                 file=sys.stderr,
             )
             continue
+        if not isinstance(fp, str):
+            print(
+                f"Warning: skipping malformed baseline entry (non-string 'fingerprint'): {entry!r}",
+                file=sys.stderr,
+            )
+            continue
         fps.add(fp)
     return fps
 
@@ -4283,6 +4289,7 @@ def _escape_workflow_value(s: str) -> str:
         .replace("\r", "%0D")
         .replace("\n", "%0A")
         .replace(":", "%3A")
+        .replace(",", "%2C")
     )
 
 

--- a/tests/test_detector.py
+++ b/tests/test_detector.py
@@ -3616,17 +3616,33 @@ def test_github_format_escapes_workflow_commands(tmp_path, capsys):
     assert _escape_workflow_data("a:b") == "a:b"
     assert _escape_workflow_data("line1\nline2") == "line1%0Aline2"
 
+    # Comma escaping
+    assert _escape_workflow_value("a,b") == "a%2Cb"
+
     # Integration: scan code with a finding and verify github output is escaped
     p = _write_py(tmp_path, "def foo(x=[]):\n    pass\n")
     findings = scan_path(p)
-    print_findings(findings, output_format="github")
+    assert findings, "expected at least one finding for the integration check"
+    _run_cli(str(p), "--format", "github")
     out = capsys.readouterr().out
     # No raw newlines inside an annotation line (each annotation is one line)
     for line in out.strip().split("\n"):
         if line.startswith("::"):
-            # The title property value should not contain unescaped colons
-            # (colons in the title= value are escaped)
+            # Must have the expected annotation structure
             assert "title=" in line
+            # No bare '::' sequences inside the property section (before the closing '::')
+            # The format is ::level prop=val,...::message — extract the properties section
+            inner = line[2:]  # strip leading '::'
+            prop_section, _, _message = inner.partition("::")
+            # No unescaped colons inside property values (colons only appear as key=value separators
+            # for the level keyword at the very start, not inside values)
+            parts = prop_section.split(" ", 1)  # "level props"
+            if len(parts) == 2:
+                props_str = parts[1]
+                for prop in props_str.split(","):
+                    if "=" in prop:
+                        _key, _, val = prop.partition("=")
+                        assert ":" not in val, f"unescaped colon in annotation property value: {val!r}"
 
 
 def test_baseline_malformed_entry_no_crash(tmp_path, capsys):


### PR DESCRIPTION
<!-- template:bugfix -->

## What does this PR fix?

Four output/config bugs:
- #77: Finding.category mismatches _RULE_REGISTRY.family (9 rules)
- #80: architecture_first phase ordering hardcodes 9-phase indices
- #81: GitHub Actions format vulnerable to log injection via unescaped messages
- #82: _load_baseline crashes with KeyError on malformed entries

Fixes #77, fixes #80, fixes #81, fixes #82

## Root cause

- **#77**: `_add()` calls used hardcoded category strings instead of deriving from registry
- **#80**: Phase order `[0,1,7,8,2,3,4,5,6]` assumed exactly 9 phases
- **#81**: `_print_github_annotations` interpolated fields without escaping `::` or newlines
- **#82**: `_load_baseline` accessed `entry["fingerprint"]` without checking key exists

## Checklist

- [x] `pytest tests/ -v` passes
- [x] Added a regression test in `tests/test_regressions.py`
- [x] `smellcheck src/smellcheck/` self-check runs clean
- [x] No dependencies added (stdlib only)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Test plan

- [x] test_finding_category_matches_registry_family
- [x] test_compute_plan_architecture_first_valid_indices
- [x] test_github_format_escapes_workflow_commands
- [x] test_baseline_malformed_entry_no_crash

## Additional context

Closes #77, closes #80, closes #81, closes #82. #81 is a security fix (CWE-117).