### PR TITLE
perf: Tarjan SCC cycle detection and _is_elif parent map cache (#86, #87)

### DIFF
--- a/plugins/python-refactoring/skills/python-refactoring/scripts/smellcheck/detector.py
+++ b/plugins/python-refactoring/skills/python-refactoring/scripts/smellcheck/detector.py
@@ -3253,6 +3253,11 @@ class SmellDetector(ast.NodeVisitor):
 
     def visit_Module(self, node: ast.Module):
         self._module_node = node
+        # Build parent map once for O(1) elif lookups (avoids O(n) ast.walk per If node)
+        self._parent_map: dict[ast.AST, ast.AST] = {}
+        for parent in ast.walk(node):
+            for child in ast.iter_child_nodes(parent):
+                self._parent_map[child] = parent
         # SC704: scan top-level for async defs and sync I/O imports
         for stmt in node.body:
             if isinstance(stmt, ast.AsyncFunctionDef):
@@ -3386,19 +3391,10 @@ class SmellDetector(ast.NodeVisitor):
 
     def _is_elif(self, node: ast.If) -> bool:
         """Check if this If node is an elif (nested inside another If's orelse)."""
-        # Walk up through the parent chain by checking func/class bodies
-        # Since ast doesn't track parents, we check the enclosing scope's body
-        if self._func_stack:
-            scope = self._func_stack[-1]
-        elif self._module_node is not None:
-            scope = self._module_node
-        else:
+        parent = self._parent_map.get(node)
+        if parent is None:
             return False
-        for parent in ast.walk(scope):
-            if isinstance(parent, ast.If) and parent is not node:
-                if len(parent.orelse) == 1 and parent.orelse[0] is node:
-                    return True
-        return False
+        return isinstance(parent, ast.If) and len(parent.orelse) == 1 and parent.orelse[0] is node
 
     def visit_For(self, node: ast.For):
         self._check_loop_append(node)
@@ -3720,48 +3716,67 @@ def _build_import_graph(
     return import_graph
 
 
+def _tarjan_scc(graph: dict[str, set[str]]) -> list[list[str]]:
+    """Find all strongly connected components via Tarjan's algorithm.
+
+    Returns only SCCs with 2+ nodes (i.e. actual cycles), in O(V+E) time.
+    """
+    index_counter = [0]
+    stack: list[str] = []
+    on_stack: set[str] = set()
+    indices: dict[str, int] = {}
+    lowlinks: dict[str, int] = {}
+    sccs: list[list[str]] = []
+
+    def strongconnect(v: str) -> None:
+        indices[v] = index_counter[0]
+        lowlinks[v] = index_counter[0]
+        index_counter[0] += 1
+        stack.append(v)
+        on_stack.add(v)
+
+        for w in graph.get(v, set()):
+            if w not in indices:
+                strongconnect(w)
+                lowlinks[v] = min(lowlinks[v], lowlinks[w])
+            elif w in on_stack:
+                lowlinks[v] = min(lowlinks[v], indices[w])
+
+        if lowlinks[v] == indices[v]:
+            scc: list[str] = []
+            while True:
+                w = stack.pop()
+                on_stack.discard(w)
+                scc.append(w)
+                if w == v:
+                    break
+            if len(scc) > 1:  # only report cycles (SCC with 2+ nodes)
+                sccs.append(scc)
+
+    for v in graph:
+        if v not in indices:
+            strongconnect(v)
+
+    return sccs
+
+
 def _detect_cyclic_imports(all_data: list[FileData]) -> list[Finding]:
-    """SC503 -- Circular imports via DFS on intra-project import graph."""
+    """SC503 -- Circular imports via Tarjan SCC on intra-project import graph."""
     module_map, reverse_map = _build_module_maps(all_data)
     import_graph = _build_import_graph(all_data, module_map, reverse_map)
 
-    visited: set[str] = set()
-    in_stack: set[str] = set()
-    raw_cycles: list[tuple[str, ...]] = []
+    sccs = _tarjan_scc(import_graph)
 
-    def _dfs(node: str, path: list[str]):
-        if node in in_stack:
-            # Extract the cycle from path: find where 'node' first appears
-            idx = path.index(node)
-            cycle = tuple(path[idx:])
-            raw_cycles.append(cycle)
-            return
-        if node in visited:
-            return
-        visited.add(node)
-        in_stack.add(node)
-        path.append(node)
-        for neighbor in import_graph.get(node, set()):
-            _dfs(neighbor, path)
-        path.pop()
-        in_stack.discard(node)
-
-    for module in import_graph:
-        visited.clear()
-        in_stack.clear()
-        _dfs(module, [])
-
-    # Deduplicate cycles: normalize each cycle by rotating to its minimum
-    # element, then use the tuple as the dedup key.
     findings: list[Finding] = []
     reported: set[tuple[str, ...]] = set()
-    for cycle in raw_cycles:
-        min_idx = cycle.index(min(cycle))
-        normalized = cycle[min_idx:] + cycle[:min_idx]
-        key = normalized
-        if key in reported:
+    for scc in sccs:
+        # Normalize: rotate to minimum element for stable deduplication
+        min_elem = min(scc)
+        min_idx = scc.index(min_elem)
+        normalized = tuple(scc[min_idx:] + scc[:min_idx])
+        if normalized in reported:
             continue
-        reported.add(key)
+        reported.add(normalized)
         cycle_str = " -> ".join(f"`{m}`" for m in normalized) + " -> `" + normalized[0] + "`"
         findings.append(
             _make_finding(

--- a/plugins/python-refactoring/skills/python-refactoring/scripts/smellcheck/detector.py
+++ b/plugins/python-refactoring/skills/python-refactoring/scripts/smellcheck/detector.py
@@ -3770,10 +3770,20 @@ def _detect_cyclic_imports(all_data: list[FileData]) -> list[Finding]:
     findings: list[Finding] = []
     reported: set[tuple[str, ...]] = set()
     for scc in sccs:
-        # Normalize: rotate to minimum element for stable deduplication
-        min_elem = min(scc)
-        min_idx = scc.index(min_elem)
-        normalized = tuple(scc[min_idx:] + scc[:min_idx])
+        # Reconstruct actual import order by walking the graph from min element
+        scc_set = set(scc)
+        start = min(scc)
+        ordered: list[str] = [start]
+        visited_in_chain: set[str] = {start}
+        current = start
+        while True:
+            nexts = [n for n in import_graph.get(current, set()) if n in scc_set and n not in visited_in_chain]
+            if not nexts:
+                break
+            current = min(nexts)  # deterministic choice
+            ordered.append(current)
+            visited_in_chain.add(current)
+        normalized = tuple(ordered)
         if normalized in reported:
             continue
         reported.add(normalized)

--- a/plugins/python-refactoring/skills/python-refactoring/scripts/smellcheck/detector.py
+++ b/plugins/python-refactoring/skills/python-refactoring/scripts/smellcheck/detector.py
@@ -3783,9 +3783,9 @@ def _detect_cyclic_imports(all_data: list[FileData]) -> list[Finding]:
             current = min(nexts)  # deterministic choice
             ordered.append(current)
             visited_in_chain.add(current)
-        # Verify closing edge exists; if not, fall back to sorted member list
+        # Use arrow notation only if walk visited all members and closing edge exists
         last = ordered[-1]
-        if start in import_graph.get(last, set()):
+        if len(ordered) == len(scc_set) and start in import_graph.get(last, set()):
             cycle_str = " -> ".join(f"`{m}`" for m in ordered) + " -> `" + ordered[0] + "`"
         else:
             cycle_str = ", ".join(f"`{m}`" for m in sorted(scc_set))

--- a/plugins/python-refactoring/skills/python-refactoring/scripts/smellcheck/detector.py
+++ b/plugins/python-refactoring/skills/python-refactoring/scripts/smellcheck/detector.py
@@ -3783,11 +3783,16 @@ def _detect_cyclic_imports(all_data: list[FileData]) -> list[Finding]:
             current = min(nexts)  # deterministic choice
             ordered.append(current)
             visited_in_chain.add(current)
-        normalized = tuple(ordered)
+        # Verify closing edge exists; if not, fall back to sorted member list
+        last = ordered[-1]
+        if start in import_graph.get(last, set()):
+            cycle_str = " -> ".join(f"`{m}`" for m in ordered) + " -> `" + ordered[0] + "`"
+        else:
+            cycle_str = ", ".join(f"`{m}`" for m in sorted(scc_set))
+        normalized = tuple(sorted(scc_set))  # canonical key regardless of walk order
         if normalized in reported:
             continue
         reported.add(normalized)
-        cycle_str = " -> ".join(f"`{m}`" for m in normalized) + " -> `" + normalized[0] + "`"
         findings.append(
             _make_finding(
                 file=reverse_map.get(normalized[0], normalized[0]),

--- a/src/smellcheck/detector.py
+++ b/src/smellcheck/detector.py
@@ -3253,6 +3253,11 @@ class SmellDetector(ast.NodeVisitor):
 
     def visit_Module(self, node: ast.Module):
         self._module_node = node
+        # Build parent map once for O(1) elif lookups (avoids O(n) ast.walk per If node)
+        self._parent_map: dict[ast.AST, ast.AST] = {}
+        for parent in ast.walk(node):
+            for child in ast.iter_child_nodes(parent):
+                self._parent_map[child] = parent
         # SC704: scan top-level for async defs and sync I/O imports
         for stmt in node.body:
             if isinstance(stmt, ast.AsyncFunctionDef):
@@ -3386,19 +3391,10 @@ class SmellDetector(ast.NodeVisitor):
 
     def _is_elif(self, node: ast.If) -> bool:
         """Check if this If node is an elif (nested inside another If's orelse)."""
-        # Walk up through the parent chain by checking func/class bodies
-        # Since ast doesn't track parents, we check the enclosing scope's body
-        if self._func_stack:
-            scope = self._func_stack[-1]
-        elif self._module_node is not None:
-            scope = self._module_node
-        else:
+        parent = self._parent_map.get(node)
+        if parent is None:
             return False
-        for parent in ast.walk(scope):
-            if isinstance(parent, ast.If) and parent is not node:
-                if len(parent.orelse) == 1 and parent.orelse[0] is node:
-                    return True
-        return False
+        return isinstance(parent, ast.If) and len(parent.orelse) == 1 and parent.orelse[0] is node
 
     def visit_For(self, node: ast.For):
         self._check_loop_append(node)
@@ -3720,48 +3716,67 @@ def _build_import_graph(
     return import_graph
 
 
+def _tarjan_scc(graph: dict[str, set[str]]) -> list[list[str]]:
+    """Find all strongly connected components via Tarjan's algorithm.
+
+    Returns only SCCs with 2+ nodes (i.e. actual cycles), in O(V+E) time.
+    """
+    index_counter = [0]
+    stack: list[str] = []
+    on_stack: set[str] = set()
+    indices: dict[str, int] = {}
+    lowlinks: dict[str, int] = {}
+    sccs: list[list[str]] = []
+
+    def strongconnect(v: str) -> None:
+        indices[v] = index_counter[0]
+        lowlinks[v] = index_counter[0]
+        index_counter[0] += 1
+        stack.append(v)
+        on_stack.add(v)
+
+        for w in graph.get(v, set()):
+            if w not in indices:
+                strongconnect(w)
+                lowlinks[v] = min(lowlinks[v], lowlinks[w])
+            elif w in on_stack:
+                lowlinks[v] = min(lowlinks[v], indices[w])
+
+        if lowlinks[v] == indices[v]:
+            scc: list[str] = []
+            while True:
+                w = stack.pop()
+                on_stack.discard(w)
+                scc.append(w)
+                if w == v:
+                    break
+            if len(scc) > 1:  # only report cycles (SCC with 2+ nodes)
+                sccs.append(scc)
+
+    for v in graph:
+        if v not in indices:
+            strongconnect(v)
+
+    return sccs
+
+
 def _detect_cyclic_imports(all_data: list[FileData]) -> list[Finding]:
-    """SC503 -- Circular imports via DFS on intra-project import graph."""
+    """SC503 -- Circular imports via Tarjan SCC on intra-project import graph."""
     module_map, reverse_map = _build_module_maps(all_data)
     import_graph = _build_import_graph(all_data, module_map, reverse_map)
 
-    visited: set[str] = set()
-    in_stack: set[str] = set()
-    raw_cycles: list[tuple[str, ...]] = []
+    sccs = _tarjan_scc(import_graph)
 
-    def _dfs(node: str, path: list[str]):
-        if node in in_stack:
-            # Extract the cycle from path: find where 'node' first appears
-            idx = path.index(node)
-            cycle = tuple(path[idx:])
-            raw_cycles.append(cycle)
-            return
-        if node in visited:
-            return
-        visited.add(node)
-        in_stack.add(node)
-        path.append(node)
-        for neighbor in import_graph.get(node, set()):
-            _dfs(neighbor, path)
-        path.pop()
-        in_stack.discard(node)
-
-    for module in import_graph:
-        visited.clear()
-        in_stack.clear()
-        _dfs(module, [])
-
-    # Deduplicate cycles: normalize each cycle by rotating to its minimum
-    # element, then use the tuple as the dedup key.
     findings: list[Finding] = []
     reported: set[tuple[str, ...]] = set()
-    for cycle in raw_cycles:
-        min_idx = cycle.index(min(cycle))
-        normalized = cycle[min_idx:] + cycle[:min_idx]
-        key = normalized
-        if key in reported:
+    for scc in sccs:
+        # Normalize: rotate to minimum element for stable deduplication
+        min_elem = min(scc)
+        min_idx = scc.index(min_elem)
+        normalized = tuple(scc[min_idx:] + scc[:min_idx])
+        if normalized in reported:
             continue
-        reported.add(key)
+        reported.add(normalized)
         cycle_str = " -> ".join(f"`{m}`" for m in normalized) + " -> `" + normalized[0] + "`"
         findings.append(
             _make_finding(

--- a/src/smellcheck/detector.py
+++ b/src/smellcheck/detector.py
@@ -3770,10 +3770,20 @@ def _detect_cyclic_imports(all_data: list[FileData]) -> list[Finding]:
     findings: list[Finding] = []
     reported: set[tuple[str, ...]] = set()
     for scc in sccs:
-        # Normalize: rotate to minimum element for stable deduplication
-        min_elem = min(scc)
-        min_idx = scc.index(min_elem)
-        normalized = tuple(scc[min_idx:] + scc[:min_idx])
+        # Reconstruct actual import order by walking the graph from min element
+        scc_set = set(scc)
+        start = min(scc)
+        ordered: list[str] = [start]
+        visited_in_chain: set[str] = {start}
+        current = start
+        while True:
+            nexts = [n for n in import_graph.get(current, set()) if n in scc_set and n not in visited_in_chain]
+            if not nexts:
+                break
+            current = min(nexts)  # deterministic choice
+            ordered.append(current)
+            visited_in_chain.add(current)
+        normalized = tuple(ordered)
         if normalized in reported:
             continue
         reported.add(normalized)

--- a/src/smellcheck/detector.py
+++ b/src/smellcheck/detector.py
@@ -3783,9 +3783,9 @@ def _detect_cyclic_imports(all_data: list[FileData]) -> list[Finding]:
             current = min(nexts)  # deterministic choice
             ordered.append(current)
             visited_in_chain.add(current)
-        # Verify closing edge exists; if not, fall back to sorted member list
+        # Use arrow notation only if walk visited all members and closing edge exists
         last = ordered[-1]
-        if start in import_graph.get(last, set()):
+        if len(ordered) == len(scc_set) and start in import_graph.get(last, set()):
             cycle_str = " -> ".join(f"`{m}`" for m in ordered) + " -> `" + ordered[0] + "`"
         else:
             cycle_str = ", ".join(f"`{m}`" for m in sorted(scc_set))

--- a/src/smellcheck/detector.py
+++ b/src/smellcheck/detector.py
@@ -3783,11 +3783,16 @@ def _detect_cyclic_imports(all_data: list[FileData]) -> list[Finding]:
             current = min(nexts)  # deterministic choice
             ordered.append(current)
             visited_in_chain.add(current)
-        normalized = tuple(ordered)
+        # Verify closing edge exists; if not, fall back to sorted member list
+        last = ordered[-1]
+        if start in import_graph.get(last, set()):
+            cycle_str = " -> ".join(f"`{m}`" for m in ordered) + " -> `" + ordered[0] + "`"
+        else:
+            cycle_str = ", ".join(f"`{m}`" for m in sorted(scc_set))
+        normalized = tuple(sorted(scc_set))  # canonical key regardless of walk order
         if normalized in reported:
             continue
         reported.add(normalized)
-        cycle_str = " -> ".join(f"`{m}`" for m in normalized) + " -> `" + normalized[0] + "`"
         findings.append(
             _make_finding(
                 file=reverse_map.get(normalized[0], normalized[0]),

--- a/tests/test_detector.py
+++ b/tests/test_detector.py
@@ -3403,7 +3403,7 @@ def test_SC503_break_cyclic_import(tmp_path):
     assert any(f.pattern == "SC503" for f in findings)
 
 
-def test_tarjan_scc_complex_graph(tmp_path):
+def test_tarjan_scc_complex_graph():
     """Tarjan SCC correctly handles complex graphs: multi-node cycles, disjoint
     cycles, nodes not in any cycle, and self-loops (single-node SCCs ignored)."""
     from smellcheck.detector import _tarjan_scc

--- a/tests/test_detector.py
+++ b/tests/test_detector.py
@@ -3403,6 +3403,78 @@ def test_SC503_break_cyclic_import(tmp_path):
     assert any(f.pattern == "SC503" for f in findings)
 
 
+def test_tarjan_scc_complex_graph(tmp_path):
+    """Tarjan SCC correctly handles complex graphs: multi-node cycles, disjoint
+    cycles, nodes not in any cycle, and self-loops (single-node SCCs ignored)."""
+    from smellcheck.detector import _tarjan_scc
+
+    # Graph: a->b->c->a (3-cycle), d->e->d (2-cycle), f->g (no cycle), h->h (self-loop)
+    graph = {
+        "a": {"b"},
+        "b": {"c"},
+        "c": {"a"},
+        "d": {"e"},
+        "e": {"d"},
+        "f": {"g"},
+        "g": set(),
+        "h": {"h"},
+    }
+    sccs = _tarjan_scc(graph)
+    # Only SCCs with 2+ nodes are returned
+    scc_sets = [frozenset(s) for s in sccs]
+    assert frozenset({"a", "b", "c"}) in scc_sets
+    assert frozenset({"d", "e"}) in scc_sets
+    # f, g, h are not part of any multi-node SCC
+    all_nodes = {n for s in sccs for n in s}
+    assert "f" not in all_nodes
+    assert "g" not in all_nodes
+    assert "h" not in all_nodes
+    assert len(sccs) == 2
+
+
+def test_tarjan_scc_no_cycles():
+    """Tarjan SCC returns empty list for a DAG."""
+    from smellcheck.detector import _tarjan_scc
+
+    graph = {"a": {"b"}, "b": {"c"}, "c": set()}
+    assert _tarjan_scc(graph) == []
+
+
+def test_SC503_three_node_cycle(tmp_path):
+    """Three-module cycle is detected and reported exactly once."""
+    (tmp_path / "mod_x.py").write_text("import mod_y\n", encoding="utf-8")
+    (tmp_path / "mod_y.py").write_text("import mod_z\n", encoding="utf-8")
+    (tmp_path / "mod_z.py").write_text("import mod_x\n", encoding="utf-8")
+    findings = scan_paths(list(tmp_path.glob("*.py")))
+    sc503 = [f for f in findings if f.pattern == "SC503"]
+    assert len(sc503) == 1
+    assert "mod_x" in sc503[0].message or "mod_y" in sc503[0].message or "mod_z" in sc503[0].message
+
+
+def test_is_elif_uses_parent_map(tmp_path):
+    """_is_elif correctly identifies elif branches using the cached parent map."""
+    code = """\
+x = 1
+if x == 1:
+    pass
+elif x == 2:
+    pass
+elif x == 3:
+    pass
+else:
+    pass
+"""
+    p = _write_py(tmp_path, code)
+    # SC412 (missing else) and isinstance-chain checks depend on _is_elif
+    # working correctly. The absence of false positives on elif branches
+    # is the observable effect we can test via scan_paths.
+    findings = scan_paths([p])
+    # There should be no SC412 finding triggered on the elif branches themselves
+    sc412 = [f for f in findings if f.pattern == "SC412"]
+    # The top-level if has an else, so no SC412 expected at all
+    assert len(sc412) == 0
+
+
 def test_SC504_split_god_module(tmp_path):
     defs = "\n".join([f"def func_{i}(): pass" for i in range(35)])
     mod = tmp_path / "god.py"


### PR DESCRIPTION
<!-- template:bugfix -->

## What does this PR fix?

Two performance optimizations:
- #86: Replace O(N*E) DFS cycle detection with O(V+E) Tarjan SCC algorithm
- #87: Cache parent map in visit_Module for O(1) _is_elif lookups (was O(n) per call)

Fixes #86, fixes #87

## Root cause

- #86: DFS restarted from every node, redundantly discovering the same cycles
- #87: ast.walk(module_node) called per If node at module level

## Checklist

- [x] `pytest tests/ -v` passes
- [x] `smellcheck src/smellcheck/` self-check runs clean
- [x] No dependencies added (stdlib only)
- [x] Commit messages follow Conventional Commits

## For new smell checks
N/A

## Test plan

- [x] Tarjan SCC produces correct SCCs for complex graphs
- [x] Existing cycle detection tests still pass
- [x] _is_elif module-level tests still pass

## Additional context

Closes #86, closes #87